### PR TITLE
Use a busyloop instead of input

### DIFF
--- a/honeypots/__main__.py
+++ b/honeypots/__main__.py
@@ -243,7 +243,8 @@ def main_logic():
         if len(temp_honeypots) > 0:
             print('[x] Everything looks good!')
             if not ARGV.test:
-                input('')
+                while True:
+                    sleep(1)
             for server in temp_honeypots:
                 try:
                     if not ARGV.test:

--- a/honeypots/__main__.py
+++ b/honeypots/__main__.py
@@ -7,10 +7,36 @@ filterwarnings('ignore', category=RuntimeWarning, module='runpy')
 all_servers = ['QDNSServer', 'QFTPServer', 'QHTTPProxyServer', 'QHTTPServer', 'QHTTPSServer', 'QIMAPServer', 'QMysqlServer', 'QPOP3Server', 'QPostgresServer', 'QRedisServer', 'QSMBServer', 'QSMTPServer', 'QSOCKS5Server', 'QSSHServer', 'QTelnetServer', 'QVNCServer', 'QElasticServer', 'QMSSQLServer', 'QLDAPServer']
 temp_honeypots = []
 
-
-from signal import signal, alarm, SIGALRM, SIG_IGN
+from signal import signal, alarm, SIGALRM, SIG_IGN, SIGTERM, SIGINT
+from time import sleep
 from functools import wraps
 
+class SignalFence:
+    def __init__(self, signals_to_listen_on, interval = 1):
+        self.fence_up = True
+        self.interval = interval
+
+        for signal_to_listen_on in signals_to_listen_on:
+            signal(signal_to_listen_on, self.handle_signal)
+
+    def handle_signal(self, signum, frame):
+        self.fence_up = False
+
+    def wait_on_fence(self):
+        while self.fence_up:
+            sleep(self.interval)
+
+class Termination:
+    def __init__(self, strategy):
+        self.strategy = strategy
+
+    def await_termination(self):
+        if self.strategy == 'input':
+            input('')
+        elif self.strategy == 'signal':
+            SignalFence([SIGTERM, SIGINT]).wait_on_fence()
+        else:
+            raise Exception('Unknown termination strategy: ' + strategy)
 
 def timeout(seconds=10):
     def decorator(func):
@@ -48,7 +74,6 @@ def server_timeout(object, name):
 def main_logic():
 
     from honeypots import QDNSServer, QFTPServer, QHTTPProxyServer, QHTTPServer, QHTTPSServer, QIMAPServer, QMysqlServer, QPOP3Server, QPostgresServer, QRedisServer, QSMBServer, QSMTPServer, QSOCKS5Server, QSSHServer, QTelnetServer, QVNCServer, QMSSQLServer, QElasticServer, QLDAPServer, server_arguments, clean_all, postgres_class, setup_logger, QBSniffer, get_running_servers
-    from time import sleep
     from atexit import register
     from argparse import ArgumentParser, SUPPRESS
     from sys import stdout
@@ -74,6 +99,7 @@ def main_logic():
     ARG_PARSER_SETUP.add_argument('--list', action='store_true', help='list all available honeypots')
     ARG_PARSER_SETUP.add_argument('--kill', action='store_true', help='kill all honeypots')
     ARG_PARSER_OPTIONAL = ARG_PARSER.add_argument_group("Optional")
+    ARG_PARSER_OPTIONAL.add_argument('--termination-strategy', help='Determines the strategy to terminate by', default='input', choices=['input', 'signal'])
     ARG_PARSER_OPTIONAL.add_argument('--ip', help='Override the IP', metavar='', default='')
     ARG_PARSER_OPTIONAL.add_argument('--port', help='Override the Port (Do not use on multiple!)', metavar='', default='')
     ARG_PARSER_OPTIONAL.add_argument('--username', help='Override the username', metavar='', default='')
@@ -194,7 +220,8 @@ def main_logic():
                     print('[x] Please wait few seconds')
                     sleep(5)
     elif ARGV.setup != '':
-        print('[x] Use [Enter] to exit or python3 -m honeypots --kill')
+        if ARGV.termination_strategy == 'input':
+            print('[x] Use [Enter] to exit or python3 -m honeypots --kill')
         register(exit_handler)
 
         if ARGV.config != "":
@@ -243,8 +270,8 @@ def main_logic():
         if len(temp_honeypots) > 0:
             print('[x] Everything looks good!')
             if not ARGV.test:
-                while True:
-                    sleep(1)
+                Termination(ARGV.termination_strategy).await_termination()
+
             for server in temp_honeypots:
                 try:
                     if not ARGV.test:


### PR DESCRIPTION
This cause a behavior change - Instead of exiting the process using any key, a SIGTERM should be sent (i.e CTRL-C)

Things to think about
- Perhaps fallback to this behavior using a flag?