### PR TITLE
Add SSH log line in case of login failure

### DIFF
--- a/honeypots/ssh_server.py
+++ b/honeypots/ssh_server.py
@@ -90,6 +90,7 @@ class QSSHServer():
                 if status == 'success':
                     _q_s.logs.info({'server': 'ssh_server', 'action': 'login', 'status': status, 'src_ip': self.ip, 'src_port': self.port, 'dest_ip': _q_s.ip, 'dest_port': _q_s.port, 'username': username, 'password': password})
                     return AUTH_SUCCESSFUL
+                _q_s.logs.info({'server': 'ssh_server', 'action': 'login', 'status': status, 'src_ip': self.ip, 'src_port': self.port, 'dest_ip': _q_s.ip, 'dest_port': _q_s.port, 'username': username, 'password': password})
                 return AUTH_FAILED
 
             def check_channel_exec_request(self, channel, command):


### PR DESCRIPTION
Added a single line to SSH server, to log failed logins in addition to successful logins. In a honeypot use case, it is useful to log failed login attempts along with the attempted username and password since it gives an idea of what the attacker's brute force dictionaries look like