### PR TITLE
Update to later version of paramiko

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'requests==2.28.2',
         'requests[socks]==2.28.2',
         'impacket==0.9.24',
-        'paramiko==2.7.1',
+        'paramiko==3.1.0',
         'scapy==2.4.5',
         'service_identity==21.1.0',
         'netifaces==0.11.0'


### PR DESCRIPTION
This resolves the problem of having to specify `-o HostKeyAlgorithms=+ssh-rsa` whenever connecting to the SSH honeypot