### PR TITLE
http proxy server: don't work as an actual proxy

### DIFF
--- a/clean-up.logs
+++ b/clean-up.logs
@@ -1,4 +1,4 @@
-Wed Oct  4 18:56:22 UTC 2023
+Fri Jan 19 13:30:47 UTC 2024
 [X] honeypots
 [X] installing python3, python3-pip, autopep8 & jq
 [X] installing the pip package

--- a/clean-up.logs
+++ b/clean-up.logs
@@ -1,4 +1,4 @@
-Fri Jan 19 13:30:47 UTC 2024
+Fri Jan 19 13:37:48 UTC 2024
 [X] honeypots
 [X] installing python3, python3-pip, autopep8 & jq
 [X] installing the pip package

--- a/honeypots/data/dummy_page.html
+++ b/honeypots/data/dummy_page.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <title>Example Website</title>
+        <meta charset="utf-8" />
+        <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
+    </head>
+    <body>
+        <div>
+            <h1>Example Website</h1>
+            <p>This website is for use in dummy HTML responses. You may use this
+            document without prior coordination or asking for permission.</p>
+        </div>
+    </body>
+</html>

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,10 @@ setup(
     license="AGPL-3.0",
     license_files=("LICENSE"),
     url="https://github.com/qeeqbox/honeypots",
-    packages=["honeypots"],
+    packages=["honeypots", "honeypots.data"],
     entry_points={"console_scripts": ["honeypots=honeypots.__main__:main_logic"]},
     include_package_data=True,
+    package_data={"honeypots.data": ["*.html"]},
     install_requires=[
         "twisted==21.7.0",
         "psutil==5.9.0",

--- a/tests/test_http_proxy_server.py
+++ b/tests/test_http_proxy_server.py
@@ -30,7 +30,7 @@ SERVER_CONFIG = {
 def test_http_proxy_server(server_logs):
     sleep(1)  # give the server some time to start
 
-    response = requests.get("http://example.com/", proxies={"http": f"http://{IP}:{PORT}"})
+    response = requests.get("http://example.com/", proxies={"http": f"http://{IP}:{PORT}"}, timeout=2)
 
     sleep(1)  # give the server process some time to write logs
 
@@ -42,3 +42,6 @@ def test_http_proxy_server(server_logs):
 
     assert query["data"] == "example.com"
     assert query["action"] == "query"
+
+    assert response.ok
+    assert "Example Website" in response.text, "dummy response is missing"

--- a/tests/test_telnet_server.py
+++ b/tests/test_telnet_server.py
@@ -24,6 +24,8 @@ PORT = "50023"
     indirect=True,
 )
 def test_telnet_server(server_logs):
+    sleep(1)  # give the server some time to start
+
     telnet_client = Telnet(IP, int(PORT))
     telnet_client.read_until(b"login: ")
     telnet_client.write(USERNAME.encode() + b"\n")


### PR DESCRIPTION
As #43 pointed out, it is not a good idea for a honeypot to work as an actual proxy server, because this can be misused in a malicious way.

This PR tries to solve this by returning a dummy website instead of the actual website and was based on #44.

- adds a dummy website and adds it to the installation
- returns the dummy website instead of the actual website in `http_proxy_server.py`
- adds a wait time to fix problems with a flaky test

resolves #43