### PR TITLE
base server config bug fix

### DIFF
--- a/honeypots/base_server.py
+++ b/honeypots/base_server.py
@@ -28,13 +28,13 @@ class BaseServer(ABC):
     def __init__(self, **kwargs):
         self.auto_disabled = None
         self.process = None
-        self.uuid = f"honeypotslogger_{__class__.__name__}_{str(uuid4())[:8]}"
+        self.uuid = f"honeypotslogger_{self.__class__.__name__}_{str(uuid4())[:8]}"
         self.config = kwargs.get("config", "")
         if self.config:
-            self.logs = setup_logger(__class__.__name__, self.uuid, self.config)
+            self.logs = setup_logger(self.__class__.__name__, self.uuid, self.config)
             set_local_vars(self, self.config)
         else:
-            self.logs = setup_logger(__class__.__name__, self.uuid, None)
+            self.logs = setup_logger(self.__class__.__name__, self.uuid, None)
         self.ip = kwargs.get("ip", None) or (hasattr(self, "ip") and self.ip) or "0.0.0.0"
         self.port = (
             (kwargs.get("port", None) and int(kwargs.get("port", None)))


### PR DESCRIPTION
this PR fixes a bug in the base server class where a missing `self.` leads to the individual server configuration not being applied correctly