### PR TITLE
Multiprocessing

### DIFF
--- a/honeypots/__main__.py
+++ b/honeypots/__main__.py
@@ -206,7 +206,7 @@ class HoneypotsManager:
         running_honeypots = {"good": [], "bad": []}
         if len(self.honeypots) > 0:
             for _, server_name, status in self.honeypots:
-                if status is False or status is None:
+                if not status:
                     running_honeypots["bad"].append(server_name)
                 else:
                     running_honeypots["good"].append(server_name)

--- a/honeypots/helper.py
+++ b/honeypots/helper.py
@@ -241,15 +241,6 @@ def kill_servers(name):
                 process.kill()
 
 
-def check_if_server_is_running(uuid):
-    with suppress(Exception):
-        for process in process_iter():
-            cmdline = " ".join(process.cmdline())
-            if "--custom" in cmdline and uuid in cmdline:
-                return True
-    return False
-
-
 def kill_server_wrapper(server_name, name, process):
     with suppress(Exception):
         if process is not None:
@@ -298,11 +289,6 @@ def close_port_wrapper(server_name, ip, port, logs):
 class ComplexEncoder(JSONEncoder):
     def default(self, obj):
         return repr(obj).replace("\x00", " ")
-
-
-class ComplexEncoder_db(JSONEncoder):
-    def default(self, obj):
-        return "Something wrong, deleted.."
 
 
 def serialize_object(_dict):

--- a/honeypots/helper.py
+++ b/honeypots/helper.py
@@ -27,10 +27,11 @@ from socket import AF_INET, SOCK_STREAM, socket
 from sqlite3 import connect as sqlite3_connect
 from sys import stdout
 from tempfile import _get_candidate_names, gettempdir, NamedTemporaryFile
-from time import sleep
+from time import sleep, time
 from typing import Any, Iterator
 from urllib.parse import urlparse
 
+import psutil
 from OpenSSL import crypto
 from psutil import process_iter
 from psycopg2 import connect as psycopg2_connect, sql
@@ -728,3 +729,25 @@ def get_headers_and_ip_from_request(request, options):
     if client_ip == "":
         client_ip = request.getClientAddress().host
     return client_ip, headers
+
+
+def service_has_started(port: int):
+    try:
+        wait_for_service(port)
+        return True
+    except TimeoutError:
+        return False
+
+
+def wait_for_service(port: int, interval: float = 0.1, timeout: int = 5.0):
+    start_time = time()
+    while True:
+        if _service_runs(port):
+            return
+        sleep(interval)
+        if time() - start_time > timeout:
+            raise TimeoutError()
+
+
+def _service_runs(port: int) -> bool:
+    return any(service.laddr.port == port for service in psutil.net_connections())

--- a/honeypots/qbsniffer.py
+++ b/honeypots/qbsniffer.py
@@ -10,11 +10,6 @@
 //  -------------------------------------------------------------
 """
 
-from warnings import filterwarnings
-from cryptography.utils import CryptographyDeprecationWarning
-
-filterwarnings(action="ignore", category=CryptographyDeprecationWarning)
-
 from binascii import hexlify
 from multiprocessing import Process
 from re import compile as rcompile, search as rsearch
@@ -22,9 +17,10 @@ from sys import stdout
 from uuid import uuid4
 
 from netifaces import AF_INET, AF_LINK, ifaddresses
-from scapy.all import *
+from scapy.layers.inet import IP, TCP
+from scapy.sendrecv import send, sniff
 
-from honeypots.helper import setup_logger
+from honeypots.helper import server_arguments, setup_logger
 
 
 class QBSniffer:
@@ -38,7 +34,7 @@ class QBSniffer:
             (0, 0, "Echo/Ping reply"),
             (3, 0, "Destination network unreachable"),
             (3, 1, "Destination host unreachable"),
-            (3, 2, "Desination protocol unreachable"),
+            (3, 2, "Destination protocol unreachable"),
             (3, 3, "Destination port unreachable"),
             (3, 4, "Fragmentation required"),
             (3, 5, "Source route failed"),
@@ -51,7 +47,7 @@ class QBSniffer:
             (3, 12, "Host unreachable for TOS"),
             (3, 13, "Communication administratively prohibited"),
             (3, 14, "Host Precedence Violation"),
-            (3, 15, "Precendence cutoff in effect"),
+            (3, 15, "Precedence cutoff in effect"),
             (4, 0, "Source quench"),
             (5, 0, "Redirect Datagram for the Network"),
             (5, 1, "Redirect Datagram for the Host"),
@@ -290,9 +286,9 @@ class QBSniffer:
 
 
 if __name__ == "__main__":
-    from server_options import server_arguments
-
     parsed = server_arguments()
     if parsed.docker or parsed.aws or parsed.custom:
-        qsniffer = QSniffer(filter=parsed.filter, interface=parsed.interface, config=parsed.config)
+        qsniffer = QBSniffer(
+            filter=parsed.filter, interface=parsed.interface, config=parsed.config
+        )
         qsniffer.run_sniffer()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ authors = [
 ]
 description = "30 different honeypots in one package! (dhcp, dns, elastic, ftp, http proxy, https proxy, http, https, imap, ipp, irc, ldap, memcache, mssql, mysql, ntp, oracle, pjl, pop3, postgres, rdp, redis, sip, smb, smtp, snmp, socks5, ssh, telnet, vnc)"
 readme = "README.rst"
-requires-python = ">=3.8"
+# ToDo: fix smtp incompatibility with 3.12
+requires-python = ">=3.8,<3.12"
 dependencies = [
     "twisted==21.7.0",
     "psutil==5.9.0",
@@ -23,7 +24,7 @@ dependencies = [
     "impacket==0.9.24",
     "paramiko==3.1.0",
     "scapy==2.4.5",
-    "service_identity==21.1.0",
+    "service-identity==21.1.0",
     "netifaces==0.11.0",
 ]
 license = {text = "AGPL-3.0"}

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import json
 from contextlib import contextmanager
 from socket import AF_INET, IPPROTO_UDP, SOCK_DGRAM, SOCK_STREAM, socket
-from time import sleep, time
+from time import sleep
 from typing import TYPE_CHECKING
 
-import psutil
+from honeypots.helper import wait_for_service
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -63,20 +63,6 @@ def assert_login_is_logged(login: dict[str, str]):
 
 @contextmanager
 def wait_for_server(port: str | int):
-    _wait_for_service(int(port))
+    wait_for_service(int(port))
     yield
     sleep(0.5)  # give the server process some time to write logs
-
-
-def _wait_for_service(port: int, interval: float = 0.1, timeout: int = 5.0):
-    start_time = time()
-    while True:
-        if _service_runs(port):
-            return
-        sleep(interval)
-        if time() - start_time > timeout:
-            raise TimeoutError()
-
-
-def _service_runs(port: int) -> bool:
-    return any(service.laddr.port == port for service in psutil.net_connections())


### PR DESCRIPTION
- replaces `Popen` call to start servers with regular multiprocessing
  - this should considerably reduce memory consumption (when I tested it with "all" servers, the used memory decreased from ~2.1GiB to ~110 MiB)
- fixed bugs in "QBSniffer"
- added upper limit to Python version to address incompatibility of smtp_server with Python 3.12
- refactoring: removed unused functions from helper module