### PR TITLE
update dependency paramiko==3.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "requests==2.28.2",
     "requests[socks]==2.28.2",
     "impacket==0.9.24",
-    "paramiko==3.1.0",
+    "paramiko==3.5.0",
     "scapy",
     "service-identity==21.1.0",
     "netifaces==0.11.0",


### PR DESCRIPTION
Closes #76 

## Description of the changes

- This pull request updates the Paramiko dependency to avoid depreciation warning on TrippleDES lib (see upstream issue on #76)

## Local tests

After applying the change and installing honeypots, I executed some tests on the SSH module (which is the one using paramiko) and also run unit tests:

```
git clone https://github.com/italovalcy/honeypots
cd honeypots
python3 -m pip install .[dev]
python3 -m pytest
...
==================== 31 passed, 8 warnings in 19.85s ==================== 
```

Before the change:

```
python3 -m pytest
...
../../usr/local/lib/python3.11/dist-packages/paramiko/pkey.py:82
  /usr/local/lib/python3.11/dist-packages/paramiko/pkey.py:82: CryptographyDeprecationWarning: TripleDES has been moved to cryptography.hazmat.decrepit.ciphers.algorithms.TripleDES and will be removed from this module in 48.0.0.
    "cipher": algorithms.TripleDES,

../../usr/local/lib/python3.11/dist-packages/paramiko/transport.py:256
  /usr/local/lib/python3.11/dist-packages/paramiko/transport.py:256: CryptographyDeprecationWarning: TripleDES has been moved to cryptography.hazmat.decrepit.ciphers.algorithms.TripleDES and will be removed from this module in 48.0.0.
    "class": algorithms.TripleDES,
...
==================== 31 passed, 10 warnings in 19.96s ==================== 

```

Running the module manually also works as expected (testing in another terminal window with `ssh localhost -p 22`):


```
# python3 -m honeypots --setup ssh:22
[INFO] For updates, check https://github.com/qeeqbox/honeypots
[INFO] Use [Enter] to exit or python3 -m honeypots --kill
[INFO] Parsing honeypot [normal]
{"action": "process", "dest_ip": "0.0.0.0", "dest_port": "22", "server": "ssh_server", "src_ip": "0.0.0.0", "src_port": "22", "status": "success", "timestamp": "2024-10-07T15:57:12.101029"
}
[INFO] servers ssh running...
[INFO] Everything looks good!
{"action": "connection", "dest_ip": "0.0.0.0", "dest_port": "22", "server": "ssh_server", "src_ip": "127.0.0.1", "src_port": "52354", "timestamp": "2024-10-07T15:59:42.096502"}
{"action": "connection", "dest_ip": "0.0.0.0", "dest_port": "22", "server": "ssh_server", "src_ip": "127.0.0.1", "src_port": "38564", "timestamp": "2024-10-07T15:59:49.280895"}
{"action": "login", "dest_ip": "0.0.0.0", "dest_port": "22", "password": "test1", "server": "ssh_server", "src_ip": "127.0.0.1", "src_port": "38564", "status": "failed", "timestamp": "2024
-10-07T15:59:53.293101", "username": "root"}
{"action": "login", "dest_ip": "0.0.0.0", "dest_port": "22", "password": "teste2", "server": "ssh_server", "src_ip": "127.0.0.1", "src_port": "38564", "status": "failed", "timestamp": "202
4-10-07T15:59:55.572211", "username": "root"}
{"action": "login", "dest_ip": "0.0.0.0", "dest_port": "22", "password": "teste3", "server": "ssh_server", "src_ip": "127.0.0.1", "src_port": "38564", "status": "failed", "timestamp": "202
4-10-07T15:59:57.372549", "username": "root"}
```