### PR TITLE
Add adaptor-ip support to servers [test-code]

### DIFF
--- a/honeypots/__main__.py
+++ b/honeypots/__main__.py
@@ -261,6 +261,10 @@ class HoneypotsManager:
         if not server_class:
             logger.warning(f"Skipping unknown service {service}")
             return
+ # pass adaptor_ip along with other server_args
+        init_args = dict(self.server_args)
+        if hasattr(self.options, "adaptor_ip"):
+            init_args["adaptor_ip"] = self.options.adaptor_ip or None 
         server = server_class(**self.server_args)
         if not self.options.test:
             status = server.run_server(process=True, auto=auto)
@@ -472,6 +476,8 @@ def _parse_args() -> tuple[Namespace, dict[str, str | int]]:
     arg_parser_optional.add_argument(
         "--options", type=str, help="Extra options", metavar="", default=""
     )
+    # <-- Add adaptor-ip option
+    arg_parser_optional.add_argument("--adaptor-ip", help="Interface IP to bind honeypots to", metavar="", default="") 
     arg_parser_optional_2 = arg_parser.add_argument_group("General options")
     arg_parser_optional_2.add_argument(
         "--termination-strategy",

--- a/honeypots/dhcp_server.py
+++ b/honeypots/dhcp_server.py
@@ -11,7 +11,9 @@ from honeypots.helper import check_bytes, server_arguments
 class QDHCPServer(BaseServer):
     NAME = "dhcp_server"
     DEFAULT_PORT = 67
-
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.adaptor_ip = kwargs.get("adaptor_ip", None)
     def server_main(self):
         _q_s = self
 
@@ -90,9 +92,11 @@ class QDHCPServer(BaseServer):
                     }
                 )
 
+        bind_ip = self.adaptor_ip if self.adaptor_ip else ""
         reactor.listenUDP(
-            port=self.port, protocol=CustomDatagramProtocolProtocol(), interface=self.ip
+        port=self.port, protocol=CustomDatagramProtocolProtocol(), interface=bind_ip
         )
+
         reactor.run()
 
     def test_server(self, ip=None, port=None):

--- a/honeypots/dns_server.py
+++ b/honeypots/dns_server.py
@@ -19,6 +19,8 @@ class QDNSServer(BaseServer):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.resolver_addresses = [("8.8.8.8", 53)]
+        #adapter 
+        self.adaptor_ip = kwargs.get("adaptor_ip", None)
 
     def server_main(self):
         _q_s = self
@@ -66,8 +68,10 @@ class QDNSServer(BaseServer):
         self.resolver = CustomClientResolver(servers=self.resolver_addresses)
         self.factory = CustomDNSServerFactory(clients=[self.resolver])
         self.protocol = CustomDnsUdpProtocol(controller=self.factory)
-        reactor.listenUDP(self.port, self.protocol, interface=self.ip)
-        reactor.listenTCP(self.port, self.factory, interface=self.ip)
+        #adaptor
+        bind_ip = self.adaptor_ip if self.adaptor_ip else ""
+        reactor.listenUDP(self.port, self.protocol, interface=bind_ip)
+        reactor.listenTCP(self.port, self.factory, interface=bind_ip)
         reactor.run()
 
     def test_server(self, *_, domain=None, **__):

--- a/honeypots/elastic_server.py
+++ b/honeypots/elastic_server.py
@@ -18,10 +18,13 @@ class QElasticServer(BaseServer):
     NAME = "elastic_server"
     DEFAULT_PORT = 9200
     DEFAULT_USERNAME = "elastic"
+    #adaptor
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.adaptor_ip = kwargs.get("adaptor_ip", None)
 
     def server_main(self):  # noqa: C901
         _q_s = self
-
         class CustomElasticServerHandler(SimpleHTTPRequestHandler):
             server_version = ""
             sys_version = ""
@@ -310,7 +313,10 @@ class QElasticServer(BaseServer):
                 return self.key
 
         with create_certificate() as (cert, key):
-            server = CustomElasticServer((self.ip, self.port))
+
+            # Adaptor
+            bind_ip = self.adaptor_ip if self.adaptor_ip else ""
+            server = CustomElasticServer((bind_ip, self.port))
             server.set_auth_key(self.username, self.password)
             ctx = SSLContext(PROTOCOL_TLS_SERVER)
             ctx.load_cert_chain(certfile=cert, keyfile=key)

--- a/honeypots/ftp_server.py
+++ b/honeypots/ftp_server.py
@@ -32,6 +32,7 @@ class QFTPServer(BaseServer):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        self.adaptor_ip = kwargs.get("adaptor_ip", None)
         self.mocking_server = choice(
             [
                 "ProFTPD 1.2.10",
@@ -147,7 +148,10 @@ class QFTPServer(BaseServer):
         factory = FTPFactory(p)
         factory.protocol = CustomFTPProtocol
         factory.welcomeMessage = "ProFTPD 1.2.10"
-        reactor.listenTCP(port=self.port, factory=factory)
+
+        bind_ip = _q_s.adaptor_ip if _q_s.adaptor_ip else ""
+        reactor.listenTCP(port=self.port, factory=factory, interface=bind_ip)
+       
         reactor.run()
 
     def test_server(self, ip=None, port=None, username=None, password=None):

--- a/honeypots/http_proxy_server.py
+++ b/honeypots/http_proxy_server.py
@@ -24,6 +24,8 @@ class QHTTPProxyServer(BaseServer):
     def __init__(self, **kwargs):
         self.template: str | None = None
         super().__init__(**kwargs)
+        #Adaptor
+        self.adaptor_ip = kwargs.get("adaptor_ip", None)
         self.template_contents: str | None = self._load_template()
 
     def _load_template(self) -> str | None:

--- a/honeypots/http_server.py
+++ b/honeypots/http_server.py
@@ -12,10 +12,15 @@ from honeypots.helper import (
 class QHTTPServer(BaseHttpServer):
     NAME = "http_server"
     DEFAULT_PORT = 80
-
+    #Adaptor
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.adaptor_ip = kwargs.get("adaptor_ip", None)
     def server_main(self):
         resource = self.MainResource(hp_server=self)
-        reactor.listenTCP(self.port, Site(resource))
+        #Adaptor
+        bind_ip = self.adaptor_ip if self.adaptor_ip else ""
+        reactor.listenTCP(self.port, Site(resource), interface=bind_ip)
         reactor.run()
 
     def test_server(self, ip=None, port=None, username=None, password=None):

--- a/honeypots/https_server.py
+++ b/honeypots/https_server.py
@@ -13,12 +13,17 @@ from honeypots.helper import (
 class QHTTPSServer(BaseHttpServer):
     NAME = "https_server"
     DEFAULT_PORT = 443
-
+    #Adaptor
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.adaptor_ip = kwargs.get("adaptor_ip", None)
     def server_main(self):
         resource = self.MainResource(hp_server=self)
         with create_certificate() as (cert, key):
             ssl_context = ssl.DefaultOpenSSLContextFactory(key, cert)
-            reactor.listenSSL(self.port, Site(resource), ssl_context)
+            #Adaptor
+            bind_ip = self.adaptor_ip if self.adaptor_ip else ""
+            reactor.listenSSL(self.port, Site(resource), ssl_context, interface=bind_ip)
             reactor.run()
 
     def test_server(self, ip=None, port=None, username=None, password=None):

--- a/honeypots/imap_server.py
+++ b/honeypots/imap_server.py
@@ -24,6 +24,7 @@ class QIMAPServer(BaseServer):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        self.adaptor_ip = kwargs.get("adaptor_ip", None)
         self.mocking_server = choice(
             [b"OK Microsoft Exchange Server 2003 IMAP4rev1 server version 6.5.6944.0 DC9 ready"]
         )
@@ -106,7 +107,9 @@ class QIMAPServer(BaseServer):
                 return protocol
 
         factory = CustomIMAPFactory()
-        reactor.listenTCP(port=self.port, factory=factory, interface=self.ip)
+        # Adaptor
+        bind_ip = self.adaptor_ip if self.adaptor_ip else self.ip
+        reactor.listenTCP(port=self.port, factory=factory, interface=bind_ip)
         reactor.run()
 
     def test_server(self, ip=None, port=None, username=None, password=None):

--- a/honeypots/ipp_server.py
+++ b/honeypots/ipp_server.py
@@ -168,6 +168,11 @@ STATUS_CODE_BAD_REQUEST = b"\x04\x00"
 class QIPPServer(BaseServer):
     NAME = "ipp_server"
     DEFAULT_PORT = 631
+    
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+    #Adaptor
+        self.adaptor_ip = kwargs.get("adaptor_ip", None)
 
     def server_main(self):  # noqa: C901
         _q_s = self
@@ -287,7 +292,12 @@ class QIPPServer(BaseServer):
                 )
                 return version + status_code + request_id + attributes
 
-        reactor.listenTCP(self.port, Site(MainResource()))
+
+
+        #Adaptor
+        bind_ip = self.adaptor_ip if self.adaptor_ip else ""
+        reactor.listenTCP(self.port, Site(MainResource()), interface=bind_ip)
+
         reactor.run()
 
     def test_server(self, ip=None, port=None):

--- a/honeypots/irc_server.py
+++ b/honeypots/irc_server.py
@@ -15,6 +15,10 @@ class QIRCServer(BaseServer):
     NAME = "irc_server"
     DEFAULT_PORT = 6667
 
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+    #Adaptor
+        self.adaptor_ip = kwargs.get("adaptor_ip", None)
     def server_main(self):
         _q_s = self
 
@@ -63,7 +67,9 @@ class QIRCServer(BaseServer):
 
         factory = Factory()
         factory.protocol = CustomIRCProtocol
-        reactor.listenTCP(port=self.port, factory=factory, interface=self.ip)
+        #Adaptor
+        bind_ip = self.adaptor_ip if self.adaptor_ip else ""
+        reactor.listenTCP(port=self.port, factory=factory, interface=bind_ip)
         reactor.run()
 
     def test_server(self, ip=None, port=None, username=None, password=None):

--- a/honeypots/ldap_server.py
+++ b/honeypots/ldap_server.py
@@ -22,6 +22,11 @@ class QLDAPServer(BaseServer):
     NAME = "ldap_server"
     DEFAULT_PORT = 389
 
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+    #Adaptor
+        self.adaptor_ip = kwargs.get("adaptor_ip", None)
+
     def server_main(self):  # noqa: C901
         _q_s = self
 
@@ -92,7 +97,9 @@ class QLDAPServer(BaseServer):
 
         factory = Factory()
         factory.protocol = CustomLDAProtocol
-        reactor.listenTCP(port=self.port, factory=factory, interface=self.ip)
+        #Adaptor
+        bind_ip = self.adaptor_ip if self.adaptor_ip else ""
+        reactor.listenTCP(port=self.port, factory=factory, interface=bind_ip)
         reactor.run()
 
     def test_server(self, ip=None, port=None, username=None, password=None):

--- a/honeypots/memcache_server.py
+++ b/honeypots/memcache_server.py
@@ -15,6 +15,11 @@ class QMemcacheServer(BaseServer):
     NAME = "memcache_server"
     DEFAULT_PORT = 11211
 
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+    #Adaptor
+        self.adaptor_ip = kwargs.get("adaptor_ip", None)
+        
     def server_main(self):  # noqa: C901
         _q_s = self
 
@@ -151,7 +156,9 @@ class QMemcacheServer(BaseServer):
 
         factory = Factory()
         factory.protocol = CustomRedisProtocol
-        reactor.listenTCP(port=self.port, factory=factory, interface=self.ip)
+        #Adaptor
+        bind_ip = self.adaptor_ip if self.adaptor_ip else ""
+        reactor.listenTCP(port=self.port, factory=factory, interface=bind_ip)
         reactor.run()
 
     def test_server(self, ip=None, port=None, username=None, password=None):  # noqa: ARG002

--- a/honeypots/mssql_server.py
+++ b/honeypots/mssql_server.py
@@ -23,6 +23,8 @@ class QMSSQLServer(BaseServer):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        #Adaptor
+        self.adaptor_ip = kwargs.get("adaptor_ip", None)
         self.file_name = None
 
     def server_main(self):  # noqa: C901
@@ -112,7 +114,9 @@ class QMSSQLServer(BaseServer):
 
         factory = Factory()
         factory.protocol = CustomMSSQLProtocol
-        reactor.listenTCP(port=self.port, factory=factory, interface=self.ip)
+        #Adaptor
+        bind_ip = self.adaptor_ip if self.adaptor_ip else ""
+        reactor.listenTCP(port=self.port, factory=factory, interface=bind_ip)
         reactor.run()
 
     def test_server(self, ip=None, port=None, username=None, password=None):

--- a/honeypots/mysql_server.py
+++ b/honeypots/mysql_server.py
@@ -21,6 +21,8 @@ class QMysqlServer(BaseServer):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        #Adaptor
+        self.adaptor_ip = kwargs.get("adaptor_ip", None)
         if hasattr(self, "file_name"):
             self.words = Path(self.file_name).read_text("utf-8").splitlines()
         else:
@@ -147,7 +149,9 @@ class QMysqlServer(BaseServer):
 
         factory = Factory()
         factory.protocol = CustomMysqlProtocol
-        reactor.listenTCP(port=self.port, factory=factory, interface=self.ip)
+        #Adaptor
+        bind_ip = self.adaptor_ip if self.adaptor_ip else ""
+        reactor.listenTCP(port=self.port, factory=factory, interface=bind_ip)
         reactor.run()
 
     def test_server(self, ip=None, port=None, username=None, password=None):

--- a/honeypots/ntp_server.py
+++ b/honeypots/ntp_server.py
@@ -16,6 +16,12 @@ class QNTPServer(BaseServer):
     NAME = "ntp_server"
     DEFAULT_PORT = 123
 
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        #Adaptor
+        self.adaptor_ip = kwargs.get("adaptor_ip", None)
+
+
     def server_main(self):
         _q_s = self
 
@@ -72,9 +78,10 @@ class QNTPServer(BaseServer):
                         "data": {"version": version, "mode": mode},
                     }
                 )
-
+        #Adaptor
+        bind_ip = self.adaptor_ip if self.adaptor_ip else ""
         reactor.listenUDP(
-            port=self.port, protocol=CustomDatagramProtocolProtocol(), interface=self.ip
+            port=self.port, protocol=CustomDatagramProtocolProtocol(), interface=bind_ip
         )
         reactor.run()
 

--- a/honeypots/oracle_server.py
+++ b/honeypots/oracle_server.py
@@ -15,7 +15,11 @@ from honeypots.helper import (
 class QOracleServer(BaseServer):
     NAME = "oracle_server"
     DEFAULT_PORT = 1521
-
+   
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        #Adaptor
+        self.adaptor_ip = kwargs.get("adaptor_ip", None)
     def server_main(self):  # noqa: C901
         _q_s = self
 
@@ -94,7 +98,9 @@ class QOracleServer(BaseServer):
 
         factory = Factory()
         factory.protocol = CustomRedisProtocol
-        reactor.listenTCP(port=self.port, factory=factory, interface=self.ip)
+        #Adaptor
+        bind_ip = self.adaptor_ip if self.adaptor_ip else ""
+        reactor.listenTCP(port=self.port, factory=factory, interface=bind_ip)
         reactor.run()
 
     def test_server(self, ip=None, port=None, username=None, password=None):  # noqa: ARG002

--- a/honeypots/pjl_server.py
+++ b/honeypots/pjl_server.py
@@ -16,6 +16,8 @@ class QPJLServer(BaseServer):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        #Adaptor
+        self.adaptor_ip = kwargs.get("adaptor_ip", None)
         self.printer = b"Brother HL-L2360"
         self.template = {
             "ProductName": "Brother HL-L2360",
@@ -78,7 +80,9 @@ class QPJLServer(BaseServer):
 
         factory = Factory()
         factory.protocol = Custompjlrotocol
-        reactor.listenTCP(port=self.port, factory=factory, interface=self.ip)
+        #Adaptor
+        bind_ip = self.adaptor_ip if self.adaptor_ip else ""
+        reactor.listenTCP(port=self.port, factory=factory, interface=bind_ip)
         reactor.run()
 
     def test_server(self, ip=None, port=None, username=None, password=None):  # noqa: ARG002

--- a/honeypots/pop3_server.py
+++ b/honeypots/pop3_server.py
@@ -16,6 +16,8 @@ class QPOP3Server(BaseServer):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        #Adaptor
+        self.adaptor_ip = kwargs.get("adaptor_ip", None)
         self.mocking_server = "Microsoft Exchange POP3 service is ready"
 
     def server_main(self):  # noqa: C901
@@ -95,7 +97,9 @@ class QPOP3Server(BaseServer):
                 return p
 
         factory = CustomPOP3Factory()
-        reactor.listenTCP(port=self.port, factory=factory, interface=self.ip)
+        #Adaptor
+        bind_ip = self.adaptor_ip if self.adaptor_ip else ""
+        reactor.listenTCP(port=self.port, factory=factory, interface=bind_ip)
         reactor.run()
 
     def test_server(self, ip=None, port=None, username=None, password=None):

--- a/honeypots/postgres_server.py
+++ b/honeypots/postgres_server.py
@@ -13,6 +13,12 @@ class QPostgresServer(BaseServer):
     NAME = "postgres_server"
     DEFAULT_PORT = 5432
 
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+    #Adaptor
+        self.adaptor_ip = kwargs.get("adaptor_ip", None)
+        
     def server_main(self):  # noqa: C901
         _q_s = self
 
@@ -70,7 +76,9 @@ class QPostgresServer(BaseServer):
 
         factory = Factory()
         factory.protocol = CustomPostgresProtocol
-        reactor.listenTCP(port=self.port, factory=factory, interface=self.ip)
+        #Adaptor
+        bind_ip = self.adaptor_ip if self.adaptor_ip else ""
+        reactor.listenTCP(port=self.port, factory=factory, interface=bind_ip)
         reactor.run()
 
     def test_server(self, ip=None, port=None, username=None, password=None):

--- a/honeypots/rdp_server.py
+++ b/honeypots/rdp_server.py
@@ -16,6 +16,11 @@ class QRDPServer(BaseServer):
     NAME = "rdp_server"
     DEFAULT_PORT = 3389
 
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+    #Adaptor
+        self.adaptor_ip = kwargs.get("adaptor_ip", None)
+
     def server_main(self):  # noqa: C901
         _q_s = self
 
@@ -192,7 +197,9 @@ class QRDPServer(BaseServer):
 
         rpdserver = socket(AF_INET, SOCK_STREAM)
         rpdserver.setsockopt(SOL_SOCKET, SO_REUSEADDR, 1)
-        rpdserver.bind((self.ip, self.port))
+        #Adaptor
+        bind_ip = self.adaptor_ip if self.adaptor_ip else ""
+        rpdserver.bind((bind_ip, self.port))
         rpdserver.listen()
 
         with create_certificate() as (cert, key):

--- a/honeypots/redis_server.py
+++ b/honeypots/redis_server.py
@@ -16,6 +16,13 @@ class QRedisServer(BaseServer):
     NAME = "redis_server"
     DEFAULT_PORT = 6379
 
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+    #Adaptor
+        self.adaptor_ip = kwargs.get("adaptor_ip", None)
+
+
     def server_main(self):  # noqa: C901
         _q_s = self
 

--- a/honeypots/sip_server.py
+++ b/honeypots/sip_server.py
@@ -13,6 +13,11 @@ from honeypots.helper import (
 class QSIPServer(BaseServer):
     NAME = "sip_server"
     DEFAULT_PORT = 5060
+    
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+    #Adaptor
+        self.adaptor_ip = kwargs.get("adaptor_ip", None)
 
     def server_main(self):
         _q_s = self
@@ -43,8 +48,9 @@ class QSIPServer(BaseServer):
                 response = self.responseFromRequest(200, message)
                 response.creationFinished()
                 self.deliverResponse(response)
-
-        reactor.listenUDP(port=self.port, protocol=CustomSIPServer(), interface=self.ip)
+        #Adaptor
+        bind_ip = self.adaptor_ip if self.adaptor_ip else ""
+        reactor.listenUDP(port=self.port, protocol=CustomSIPServer(), interface=bind_ip)
         reactor.run()
 
     def test_server(self, ip=None, port=None, username=None, password=None):

--- a/honeypots/smb_server.py
+++ b/honeypots/smb_server.py
@@ -22,6 +22,8 @@ class QSMBServer(BaseServer):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        #Adaptor
+        self.adaptor_ip = kwargs.get("adaptor_ip", None)
         self.folders = ""
 
     def server_main(self):  # noqa: C901
@@ -90,7 +92,9 @@ class QSMBServer(BaseServer):
                 self.__server.serve_forever()
 
         with TemporaryDirectory() as tmpdir:
-            server = SimpleSMBServer(listenAddress=self.ip, listenPort=self.port)
+            #Adaptor
+            bind_ip = self.adaptor_ip if self.adaptor_ip else ""
+            server = SimpleSMBServer(listenAddress=bind_ip, listenPort=self.port)
             if self.folders == "" or self.folders is None:
                 server.addShare("C$", tmpdir, "", readOnly="yes")
             else:

--- a/honeypots/smtp_server.py
+++ b/honeypots/smtp_server.py
@@ -15,6 +15,8 @@ class QSMTPServer(BaseServer):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        #Adaptor
+        self.adaptor_ip = kwargs.get("adaptor_ip", None)
 
     def server_main(self):  # noqa: C901
         _q_s = self
@@ -80,7 +82,9 @@ class QSMTPServer(BaseServer):
                 return p
 
         factory = CustomSMTPFactory()
-        reactor.listenTCP(port=self.port, factory=factory, interface=self.ip)
+        #Adaptor
+        bind_ip = self.adaptor_ip if self.adaptor_ip else ""
+        reactor.listenTCP(port=self.port, factory=factory, interface=bind_ip)
         reactor.run()
 
     def test_server(self, ip=None, port=None, username=None, password=None):

--- a/honeypots/sniffer.py
+++ b/honeypots/sniffer.py
@@ -71,6 +71,8 @@ class QSniffer(BaseServer):
         self.allowed_ports = []
         self.allowed_ips = []
         self.common = re.compile(rb"pass|user|login")
+        #Adaptor
+        self.adaptor_ip = kwargs.get("adaptor_ip", None)
 
     @staticmethod
     def find_icmp(type_, code):
@@ -91,7 +93,9 @@ class QSniffer(BaseServer):
 
     def server_main(self):
         try:
-            sniff(filter=self.filter, iface=self.interface, prn=self.capture_logic)
+            #Adaptor
+            bind_ip = self.adaptor_ip if self.adaptor_ip else ""
+            sniff(filter=self.filter, iface=bind_ip, prn=self.capture_logic)
         except PermissionError as error:
             self.logger.error(f"Could not start sniffer: {error}")
 

--- a/honeypots/snmp_server.py
+++ b/honeypots/snmp_server.py
@@ -12,7 +12,11 @@ from honeypots.helper import (
 class QSNMPServer(BaseServer):
     NAME = "snmp_server"
     DEFAULT_PORT = 161
-
+    
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        #Adaptor
+        self.adaptor_ip = kwargs.get("adaptor_ip", None)
     def server_main(self):
         _q_s = self
 
@@ -50,9 +54,10 @@ class QSNMPServer(BaseServer):
                         }
                     )
                     self.transport.write(b"Error", addr)
-
+        #Adaptor
+        bind_ip = self.adaptor_ip if self.adaptor_ip else ""
         reactor.listenUDP(
-            port=self.port, protocol=CustomDatagramProtocolProtocol(), interface=self.ip
+            port=self.port, protocol=CustomDatagramProtocolProtocol(), interface=bind_ip
         )
         reactor.run()
 

--- a/honeypots/socks5_server.py
+++ b/honeypots/socks5_server.py
@@ -17,6 +17,11 @@ AUTH_TYPE_USER_PW = 2
 class QSOCKS5Server(BaseServer):
     NAME = "socks5_server"
     DEFAULT_PORT = 1080
+    
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        #Adaptor
+        self.adaptor_ip = kwargs.get("adaptor_ip", None)
 
     def server_main(self):
         _q_s = self
@@ -64,7 +69,9 @@ class QSOCKS5Server(BaseServer):
             pass
 
         TCPServer.allow_reuse_address = True
-        server = ThreadingTCPServer((self.ip, self.port), CustomStreamRequestHandler)
+        #Adaptor
+        bind_ip = self.adaptor_ip if self.adaptor_ip else ""
+        server = ThreadingTCPServer((bind_ip, self.port), CustomStreamRequestHandler)
         server.serve_forever()
 
     def test_server(self, ip=None, port=None, username=None, password=None):

--- a/honeypots/ssh_server.py
+++ b/honeypots/ssh_server.py
@@ -75,6 +75,8 @@ class QSSHServer(BaseServer):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        #Adaptor
+        self.adaptor_ip = kwargs.get("adaptor_ip", None)
         self.mocking_server = choice(
             ["OpenSSH 7.5", "OpenSSH 7.3", "Serv-U SSH Server 15.1.1.108", "OpenSSH 6.4"]
         )
@@ -197,7 +199,9 @@ class QSSHServer(BaseServer):
 
         sock = socket(AF_INET, SOCK_STREAM)
         sock.setsockopt(SOL_SOCKET, SO_REUSEADDR, 1)
-        sock.bind((self.ip, self.port))
+        #Adaptor
+        bind_ip = self.adaptor_ip if self.adaptor_ip else ""
+        sock.bind((bind_ip, self.port))
         sock.listen(1)
         private_key = self.generate_pub_pri_keys()
         while True:

--- a/honeypots/telnet_server.py
+++ b/honeypots/telnet_server.py
@@ -17,6 +17,8 @@ class QTelnetServer(BaseServer):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        #Adaptor
+        self.adaptor_ip = kwargs.get("adaptor_ip", None)
         self.random_servers = [
             "Ubuntu 18.04 LTS",
             "Ubuntu 16.04.3 LTS",
@@ -67,7 +69,9 @@ class QTelnetServer(BaseServer):
 
         factory = Factory()
         factory.protocol = lambda: TelnetTransport(CustomTelnetProtocol)
-        reactor.listenTCP(port=self.port, factory=factory, interface=self.ip)
+        #Adaptor
+        bind_ip = self.adaptor_ip if self.adaptor_ip else ""
+        reactor.listenTCP(port=self.port, factory=factory, interface=bind_ip)
         reactor.run()
 
     def test_server(self, ip=None, port=None, username=None, password=None):

--- a/honeypots/vnc_server.py
+++ b/honeypots/vnc_server.py
@@ -21,6 +21,8 @@ class QVNCServer(BaseServer):
     def __init__(self, **kwargs):
         self.file_name = None
         super().__init__(**kwargs)
+        #Adaptor
+        self.adaptor_ip = kwargs.get("adaptor_ip", None)
         self.challenge = bytes.fromhex("00000000901234567890123456789012")
         self.words = ["test", "admin", "123", "123456"]
         if self.file_name:
@@ -98,7 +100,9 @@ class QVNCServer(BaseServer):
 
         factory = Factory()
         factory.protocol = CustomVNCProtocol
-        reactor.listenTCP(port=self.port, factory=factory, interface=self.ip)
+        #Adaptor
+        bind_ip = self.adaptor_ip if self.adaptor_ip else ""
+        reactor.listenTCP(port=self.port, factory=factory, interface=bind_ip)
         reactor.run()
 
     def test_server(self, ip=None, port=None, username=None, password=None):


### PR DESCRIPTION
Add --adaptor-ip support to allow binding honeypots to a specific interface [test-code]

Description:
This pull request introduces support for an optional --adaptor-ip argument, enabling honeypot servers to bind to a specified network interface or IP address instead of the default. The change touches multiple server implementations to ensure consistent behavior across protocols.

Changes
Server initialization logic updated to read the adaptor_ip parameter when provided. Adjustments made across relevant modules so that the option applies uniformly to all supported services.

To Test
honeypots --setup http:2222 --adaptor-ip  192.168.1.129 --ip 192.168.1.129


Outcome will only come from one adaptor, because the server will only run one adaptor.
--------------------------------------------------------------------------------------------
root@heonypot:/opt/honey/updated/honeypots# python3 -m honeypots --setup http:2222 --adaptor-ip  192.168.1.129 --ip 192.168.1.129
[INFO] For updates, check https://github.com/qeeqbox/honeypots
[INFO] Use [Enter] to exit or python3 -m honeypots --kill
[INFO] Parsing honeypot [normal]
{"action": "process", "dest_ip": "192.168.1.129", "dest_port": "2222", "server": "http_server", "src_ip": "192.168.1.129", "src_port": "2222", "status": "success", "timestamp": "2025-12-03T11:53:43.940244"}
[INFO] servers http running...
[INFO] Everything looks good!
{"action": "connection", "dest_ip": "192.168.1.129", "dest_port": "2222", "server": "http_server", "src_ip": "192.168.1.177", "src_port": "47634", "timestamp": "2025-12-03T11:53:53.647580"}
{"action": "GET", "dest_ip": "192.168.1.129", "dest_port": "2222", "server": "http_server", "src_ip": "192.168.1.177", "src_port": "47634", "timestamp": "2025-12-03T11:53:53.647764"}

